### PR TITLE
Correct build variable names in goreleaser configuration

### DIFF
--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -14,9 +14,9 @@ builds:
     ldflags:
       - -s -w
       - -buildmode=pie
-      - -X main.version={{.Version}}
-      - -X main.commit={{.Commit}}
-      - -X main.date={{.Date}}
+      - -X main.buildVersion={{.Version}}
+      - -X main.buildCommit={{.Commit}}
+      - -X main.buildDate={{.Date}}
     flags:
       - -a
     tags:


### PR DESCRIPTION
This PR fixes the variable names in the goreleaser configuration to properly match the variable names in the Go code. The ldflags in goreleaser.yml now correctly reference the build variables (buildVersion, buildCommit, buildDate) that are defined in the main package of the application.